### PR TITLE
True ISR, show data regeneration

### DIFF
--- a/BUILD_ID.js
+++ b/BUILD_ID.js
@@ -1,1 +1,1 @@
-export const BUILD_ID= '1655457307431'
+export const BUILD_ID= '1655484558265'

--- a/pages/blogs/_slug.vue
+++ b/pages/blogs/_slug.vue
@@ -2,16 +2,20 @@
   <div class="bg-black flex flex-col items-center justify-center min-h-screen p-5 sm:p-2">
     <div class="flex flex-col max-w-[450px]">
       <h1 class="font-bold text-white text-3xl md:text-5xl">
-        {{ resp.title }}
+        {{ data.title }}
       </h1>
-      <li class="mt-5 list-none text-white" v-for="story of resp['items'].filter((item, index) => index <= 3)" :key="story.link">
-        <a target="_blank" :href="story.link">
-          <h2>&middot; {{ story.title }}</h2>
+      <li class="mt-5 list-none text-white" v-for="article of data['items']" :key="article.link">
+        <a target="_blank" :href="article.link">
+          <h2>&middot; {{ article.title }}</h2>
         </a>
       </li>
-      <span class="text-gray-400 mt-5">
-        Page generated at: {{ resp.random }}
-      </span>
+      <span class="text-gray-400 mt-5"> Page generated at: {{ data.random }} </span>
+      <button
+        @click="testISR"
+        class="mt-5 cursor-pointer text-gray-300 hover:text-white hover:bg-black shadow rounded border border-gray-500 py-2 px-3 w-[320px]"
+      >
+        Test ISR (refresh page in 60 seconds)
+      </button>
       <span class="text-gray-400 mt-5">
         &larr; Back to
         <NuxtLink class="underline" to="/">home</NuxtLink>
@@ -22,6 +26,13 @@
 
 <script>
 export default {
+  methods: {
+    testISR() {
+      setTimeout(() => {
+        window.location.reload()
+      }, 60 * 1000)
+    },
+  },
   mounted() {
     if (typeof window !== 'undefined' && window.__client__ === true) {
       window.__client__ = false
@@ -30,8 +41,8 @@ export default {
     }
   },
   head() {
-    const title = `${this.resp.title} | Static Medium [ISG in Nuxt.js with Layer0]`
-    const description = this.resp.items[0].title
+    const title = `${this.data.title} | Static Medium [ISG in Nuxt.js with Layer0]`
+    const description = this.data.items && this.data.items.length > 0 ? this.data.items[0].title : ''
     return {
       title: title,
       meta: [
@@ -104,6 +115,7 @@ export default {
   },
   async asyncData({ req, params, redirect }) {
     let link = undefined
+    let data = undefined
     // If in browser (i.e. on client side)
     if (typeof window !== 'undefined') {
       link = window.location.origin
@@ -127,12 +139,21 @@ export default {
         }
       }
     }
-    let blogsData = await fetch(`${link}/api/blogs/${params.slug}.json`).then((res) => res.json())
-    if (blogsData['code'] == 0) redirect(404, '/error')
+    let resp = await fetch(`${link}/api/blogs/${params.slug}.json`)
+    if (!resp.ok) {
+      redirect(404, '/error')
+    } else {
+      data = await resp.json()
+      if (data['code'] === 0) {
+        redirect(404, '/error')
+      }
+    }
+    data = data['resp']
+    data['items'] = data['items'].filter((item, index) => index <= 3).map((i) => ({ title: i.title, link: i.link }))
     return {
-      resp: blogsData['resp'],
-      slug: params.slug,
+      data,
       link,
+      slug: params.slug,
     }
   },
 }

--- a/routes.js
+++ b/routes.js
@@ -55,20 +55,8 @@ module.exports = new Router()
       })
     else renderWithApp()
   })
-  .get('/api/blogs/:username.json', ({ serveStatic, cache, renderWithApp }) => {
-    cache({
-      edge: {
-        maxAgeSeconds: 60,
-        staleWhileRevalidateSeconds: 60, // serve stale responses for a minute until new content is fetched, in background a new request is looking for new content
-      },
-      browser: false,
-    })
-    if (IF_PRODUCTION)
-      serveStatic('dist/blogs/:username.json', {
-        // When the user requests data that is not already statically rendered, fall back to SSR.
-        onNotFound: () => renderWithApp(),
-      })
-    else renderWithApp()
+  .get('/api/blogs/:username.json', ({ renderWithApp }) => {
+    renderWithApp()
   })
   .use(nuxtRoutes)
   .fallback(({ redirect }) => {


### PR DESCRIPTION
Fixes #9 

Updated the code to:
- Not cache the API, so that after 60 seconds you reload the blogs page to test the updated page,
- Update the page configuration to serve caches for 60 seconds when fresh response is recevied, and swr to 60 seconds (can now validate both cached and invalidated pages)
- A button to refresh page in a minute so that data changes on ISR can be demoed better.